### PR TITLE
保存時に表示するファイルの拡張子にwebmを追加

### DIFF
--- a/examples/ffmpeg-output/src/lib.rs
+++ b/examples/ffmpeg-output/src/lib.rs
@@ -225,7 +225,7 @@ impl OutputPlugin for FfmpegOutputPlugin {
             input_type: aviutl2::output::OutputType::Both,
             file_filters: vec![aviutl2::output::FileFilter {
                 name: "Video Files".to_string(),
-                extensions: vec!["mp4".to_string(), "mkv".to_string(), "avi".to_string()],
+                extensions: vec!["mp4".to_string(), "mkv".to_string(), "avi".to_string(), "webm".to_string()],
             }],
             information: "FFmpeg for AviUtl, written in Rust / https://github.com/sevenc-nanashi/aviutl2-rs/tree/main/examples/ffmpeg-output".to_string(),
             can_config: true,


### PR DESCRIPTION
現状だと、保存時に表示されるファイル拡張子は `.mp4` `.mkv` `.avi` しかありません

当方、av1+opus用のコンテナとして `.webm` を使っているので表示できると助かります

（Windows標準のプレイヤーで再生する際に `.webm` 拡張子でないとav1+opusが再生できない、という背景があります）