### PR TITLE
Use the right format tag for f32 audio

### DIFF
--- a/crates/aviutl2-sys/Cargo.toml
+++ b/crates/aviutl2-sys/Cargo.toml
@@ -4,4 +4,4 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-windows-sys = { version = "0.60.2", features = ["Win32", "Win32_Graphics_Gdi", "Win32_Media_Audio"] }
+windows-sys = { version = "0.60.2", features = ["Win32", "Win32_Graphics_Gdi", "Win32_Media_Audio", "Win32_Media_Multimedia"] }

--- a/crates/aviutl2-sys/src/input2.rs
+++ b/crates/aviutl2-sys/src/input2.rs
@@ -10,7 +10,8 @@ use std::ffi::c_void;
 pub use windows_sys::Win32::{
     Foundation::{HINSTANCE, HWND},
     Graphics::Gdi::{BI_BITFIELDS, BI_RGB, BITMAPINFOHEADER},
-    Media::Audio::{WAVE_FORMAT_PCM, WAVEFORMATEX},
+    Media::Audio::WAVEFORMATEX,
+    Media::Multimedia::WAVE_FORMAT_IEEE_FLOAT,
 };
 
 pub type LPCWSTR = *const u16;

--- a/crates/aviutl2/src/input/bridge.rs
+++ b/crates/aviutl2/src/input/bridge.rs
@@ -29,7 +29,7 @@ impl ImageFormat {
 impl AudioFormat {
     fn into_raw(self) -> aviutl2_sys::input2::WAVEFORMATEX {
         aviutl2_sys::input2::WAVEFORMATEX {
-            wFormatTag: aviutl2_sys::input2::WAVE_FORMAT_PCM as u16,
+            wFormatTag: aviutl2_sys::input2::WAVE_FORMAT_IEEE_FLOAT as u16,
             nChannels: self.channels,
             nSamplesPerSec: self.sample_rate,
             nAvgBytesPerSec: (self.sample_rate * (self.channels as u32) * 4),


### PR DESCRIPTION
Hello! I was testing this repository for audio input plugins and encountered an issue with the format.

`WAVE_FORMAT_PCM` only supports integer types for audio. The format tag for floating point audio was in a different feature. I hope this helps!